### PR TITLE
Fix typo in README.md & Delete extra whitespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,25 @@
 # extend-luogu
 
-Make [Luogu](https://www.luogu.org/) more powerful.
+Make [Luogu](https://www.luogu.com.cn/) more powerful.
 
 ## Installation
 
-[Chinese guide](https://www.luogu.com.cn/paste/fnln7ze9)
+[Chinese Guide](https://www.luogu.com.cn/paste/fnln7ze9)
 
-Copy `extend-luogu.user.js` into Tampermonkey's `Create a new script` page, and save that.
+Copy `extend-luogu.user.js` into Tampermonkey's `Create a new script` page, and save it.
 
-_Make sure to copy the whole code._
+_Make sure to copy the code **completely**._
 
 You will be automatically notified when there's a update.
 
 ## Contribution
 
-Welcomes!
+Welcome!
 
-- Commits should obey our [CommitRule](https://github.com/ForkFG/FkGitCommitInfoStd). Since `VER 3.0.0`.
-- This repository uses [eslint](https://eslint.org/), please make sure your code is checked under `.eslintrc.js`.
+- Commits should obey our [Commit Rule](https://github.com/ForkFG/FkGitCommitInfoStd) (since `VER 3.0.0`).
+- This repository uses [eslint](https://eslint.org/), so please make sure your code will be passed under `.eslintrc.js`.
 
 ## Discussion
 
-- QQ group: `817265691`
+- QQ Group: `817265691`
 

--- a/extend-luogu.user.js
+++ b/extend-luogu.user.js
@@ -484,12 +484,12 @@ mod.reg("benben", "@/", () => {
                 <span class="feed-username">
                     <a class="lg-fg-${ color[m.user.color] }" href="/user/${ m.user.uid }" target="_blank">
                         ${ m.user.name }
-                    </a>&nbsp
+                    </a>
                     <a class="sb_amazeui" target="_blank" href="/discuss/show/142324">
                         ${ check(m.user.ccfLevel) }
                     </a>
                     ${ m.user.badge ? `<span class="am-badge am-radius lg-bg-${ color[m.user.color] }">${ m.user.badge }</span>` : "" }
-                </span>&nbsp;
+                </span>
                 ${ new Date(m.time * 1000).format("yyyy-mm-dd HH:MM") }
                 <a name="feed-reply" onclick="">回复</a>
             </div>


### PR DESCRIPTION
- 小幅度更改了一下 README.md 中的标点符号、大小写、措词使其更加通顺。
- 删去了用户名与勾之间的多余空格。
- 另外，建议将项目的简介改为 `Make Luogu more powerful.`。`Luogu` 前不需加 `The`，且句子的首字母大写。

qwq